### PR TITLE
:bug: Add missing model namespace fixing CS0234

### DIFF
--- a/TagHelperSamples/src/TagHelperSamples.Web/Views/Home/About.cshtml
+++ b/TagHelperSamples/src/TagHelperSamples.Web/Views/Home/About.cshtml
@@ -1,5 +1,5 @@
 ﻿@using System.Threading.Tasks
-@using TagHelperSamples.Model
+@using TagHelperSamples.Web.Model
 @model TestModel
 @{
     ViewData["Title"] = "About";


### PR DESCRIPTION
The project is now using subprojects (multiple assemblies) and existing
namespaces have been rewritten. Somehow namespace in the About view has been
missing that change. The commit corrects namespace
removing runtime CS0234 error.
Thanks!
