### PR TITLE
Remove unused client side libraries from project

### DIFF
--- a/TagHelperSamples/src/TagHelperSamples.Web/Views/Shared/_Layout.cshtml
+++ b/TagHelperSamples/src/TagHelperSamples.Web/Views/Shared/_Layout.cshtml
@@ -7,7 +7,6 @@
 
         <environment names="Development">
             <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
-            <link rel="stylesheet" href="~/lib/bootstrap-touch-carousel/dist/css/bootstrap-touch-carousel.css" />
             <link rel="stylesheet" href="~/css/site.css" />
            <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
         </environment>
@@ -15,9 +14,6 @@
             <link rel="stylesheet" href="//ajax.aspnetcdn.com/ajax/bootstrap/3.0.0/css/bootstrap.min.css"
                   asp-fallback-href="~/lib/bootstrap/css/bootstrap.min.css"
                   asp-fallback-test-class="hidden" asp-fallback-test-property="visibility" asp-fallback-test-value="hidden" />
-            <link rel="stylesheet" href="//ajax.aspnetcdn.com/ajax/bootstrap-touch-carousel/0.8.0/css/bootstrap-touch-carousel.css"
-                  asp-fallback-href="~/lib/bootstrap-touch-carousel/css/bootstrap-touch-carousel.css"
-                  asp-fallback-test-class="carousel-caption" asp-fallback-test-property="display" asp-fallback-test-value="none" />
             <link rel="stylesheet" href="~/css/site.css" asp-file-version="true" />
            <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
         </environment>
@@ -53,8 +49,6 @@
         <environment names="Development">
             <script src="~/lib/jquery/dist/jquery.js"></script>
             <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
-            <script src="~/lib/hammer.js/hammer.js"></script>
-            <script src="~/lib/bootstrap-touch-carousel/dist/js/bootstrap-touch-carousel.js"></script>
         </environment>
         <environment names="Staging,Production">
             <script src="//ajax.aspnetcdn.com/ajax/jquery/jquery-2.1.4.min.js"
@@ -64,14 +58,6 @@
             <script src="//ajax.aspnetcdn.com/ajax/bootstrap/3.0.0/bootstrap.min.js"
                     asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
                     asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal">
-            </script>
-            <script src="//ajax.aspnetcdn.com/ajax/hammer.js/2.0.4/hammer.min.js"
-                    asp-fallback-src="~/lib/hammer.js/hammer.js"
-                    asp-fallback-test="window.Hammer">
-            </script>
-            <script src="//ajax.aspnetcdn.com/ajax/bootstrap-touch-carousel/0.8.0/js/bootstrap-touch-carousel.js"
-                    asp-fallback-src="~/lib/bootstrap-touch-carousel/dist/js/bootstrap-touch-carousel.js"
-                    asp-fallback-test="window.Hammer && window.Hammer.Instance">
             </script>
             <script src="~/js/site.js" asp-file-version="true"></script>
         </environment>

--- a/TagHelperSamples/src/TagHelperSamples.Web/bower.json
+++ b/TagHelperSamples/src/TagHelperSamples.Web/bower.json
@@ -3,10 +3,8 @@
   "private": true,
   "dependencies": {
     "bootstrap": "3.0.0",
-    "bootstrap-touch-carousel": "0.8.0",
-    "hammer.js": "2.0.4",
-    "jquery": "2.1.4",
     "jquery-validation": "1.11.1",
-    "jquery-validation-unobtrusive": "3.2.2"
+    "jquery-validation-unobtrusive": "3.2.2",
+    "jquery": "2.1.4"
   }
 }

--- a/TagHelperSamples/src/TagHelperSamples.Web/wwwroot/_references.js
+++ b/TagHelperSamples/src/TagHelperSamples.Web/wwwroot/_references.js
@@ -2,7 +2,5 @@
 /// <reference path="../gulpfile.js" />
 /// <reference path="js/site.js" />
 /// <reference path="lib/bootstrap/dist/js/bootstrap.js" />
-/// <reference path="lib/bootstrap-touch-carousel/dist/js/bootstrap-touch-carousel.js" />
-/// <reference path="lib/hammer.js/hammer.js" />
 /// <reference path="lib/jquery/dist/jquery.js" />
 /// <reference path="lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.js" />


### PR DESCRIPTION
The bootstrap-touch-carousel and hammer.js are to be removed from
default ASP.NET templates in the future. The project does not use a Bootstrap
carousel JS component at all - so there is no requirement to use that libraries.
The change will make client side dependencies installation via Bower smaller
and minimize page loading time

http://git.io/vlHIs
http://git.io/vlHku

Thanks!
