### PR TITLE
Remove unused hosting.ini file

### DIFF
--- a/TagHelperSamples/src/TagHelperSamples.Web/hosting.ini
+++ b/TagHelperSamples/src/TagHelperSamples.Web/hosting.ini
@@ -1,2 +1,0 @@
-﻿server=Microsoft.AspNet.Server.WebListener
-server.urls=http://localhost:5000


### PR DESCRIPTION
The `hosting.ini` configuration file was removed from ASP.NET templates due to changes
related to process of web server initialization with unified Kestrel interface
https://github.com/aspnet/Templates/issues/169

Thanks!
