### PR TITLE
:memo: Improve GenFu reference note

### DIFF
--- a/TagHelperSamples/src/TagHelperSamples.Web/Views/Samples/GenFuTagHelper.cshtml
+++ b/TagHelperSamples/src/TagHelperSamples.Web/Views/Samples/GenFuTagHelper.cshtml
@@ -3,10 +3,10 @@
 
 <hr />
 <p>
-    GenFu is a test and prototype data generation library targeting ASP.NET vNext. It understands different topics - such as "contact details" or "blog posts" and uses that understanding to to populate commonly named properties using reflection and an internal database of values or randomly created data.
+    <a href="http://genfu.io/" target="_blank">GenFu</a> is a test and prototype data generation library targeting ASP.NET 5. It understands different topics - such as "contact details" or "blog posts" and uses that understanding to to populate commonly named properties using reflection and an internal database of values or randomly created data.
 </p>
 <p>
-    You can use GenFu taghelpers to create data on the fly in your views.
+    You can use <a href="http://genfu.io/" target="_blank">GenFu</a> taghelpers to create data on the fly in your views.
 </p>
 <hr/>
 


### PR DESCRIPTION
This PR introduces changes to `GenFu` project notes:
- add links to project website
- remove/replace _vNext_ to match project copy

The intent is to provide better knowledge to the users about external project (based on my own experience).

Thanks!
