### PR TITLE
:arrow_up: Update highlight.js

### DIFF
--- a/TagHelperSamples/src/TagHelperSamples.Web/Views/Shared/_Layout.cshtml
+++ b/TagHelperSamples/src/TagHelperSamples.Web/Views/Shared/_Layout.cshtml
@@ -18,7 +18,7 @@
             <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css"
                   asp-fallback-href="~/lib/fontawesome/css/font-awesome.min.css"
                   asp-fallback-test-class="fa" asp-fallback-test-property="font-family" asp-fallback-test-value="FontAwesome" />
-            <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.0/styles/zenburn.min.css"
+            <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/zenburn.min.css"
                   asp-fallback-href="~/lib/highlightjs/styles/zenburn.css"
                   asp-fallback-test-class="hljs" asp-fallback-test-property="display" asp-fallback-test-value="block">
             <link rel="stylesheet" href="~/css/site.css" asp-file-version="true" />
@@ -67,7 +67,7 @@
                     asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
                     asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal">
             </script>
-            <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.0/highlight.min.js"
+            <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/highlight.min.js"
                     asp-fallback-src="~/lib/highlightjs/highlight.pack.min.js"
                     asp-fallback-test="window.hljs">
             </script>

--- a/TagHelperSamples/src/TagHelperSamples.Web/bower.json
+++ b/TagHelperSamples/src/TagHelperSamples.Web/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "bootstrap": "3.3.5",
     "fontawesome": "4.4.0",
-    "highlightjs": "8.8.0",
+    "highlightjs": "8.9.1",
     "jquery-validation": "1.14.0",
     "jquery-validation-unobtrusive": "3.2.4",
     "jquery": "2.1.4"


### PR DESCRIPTION
When I created #23 previously, the `highlight.js` 8.9.\* was not available on CDN, hence a small difference between versions of library. This PR fixes that problem as CND has been updated:
- use the same version for local and CDN resources
- update to patch version not available on CDN
  when PR #23 was submitted

Thanks!
Tested OS X in development env
