### PR TITLE
Fix route resolving in nav link tag helper

### DIFF
--- a/TagHelperSamples/src/TagHelperSamples.Bootstrap/NavLinkTagHelper.cs
+++ b/TagHelperSamples/src/TagHelperSamples.Bootstrap/NavLinkTagHelper.cs
@@ -16,11 +16,10 @@ namespace TagHelperSamples.Bootstrap
         {
         }
 
-        [ViewContext]
-        public ViewContext ViewContext { get; set; }
-
         public async override void Process(TagHelperContext context, TagHelperOutput output)
         {
+            base.Process(context, output);
+
             var childContent = await output.GetChildContentAsync();
             string content = childContent.GetContent();
             output.TagName = "li";


### PR DESCRIPTION
In Process(..) routes would never get resolved and hrefAttr was always null.
- base.Process(..) resolves the route.
- ViewContext hid the base member and caused a NullReferenceException

Fixes #41
