### PR TITLE
Extending NavLinkTagHelper for supporting additional parameters

### DIFF
--- a/TagHelperSamples/src/TagHelperSamples.Bootstrap/NavLinkTagHelper.cs
+++ b/TagHelperSamples/src/TagHelperSamples.Bootstrap/NavLinkTagHelper.cs
@@ -2,10 +2,8 @@
 using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace TagHelperSamples.Bootstrap
 {
@@ -42,16 +40,26 @@ namespace TagHelperSamples.Bootstrap
         {
             string currentController = ViewContext.RouteData.Values["Controller"].ToString();
             string currentAction = ViewContext.RouteData.Values["Action"].ToString();
-            bool res;
-            if (!string.IsNullOrWhiteSpace(Controller) && !string.IsNullOrWhiteSpace(Action))
-                res = Controller.ToLower() == currentController.ToLower() && Action.ToLower() == currentAction.ToLower();
-            else if (!string.IsNullOrWhiteSpace(Action))
-                res = Action.ToLower() == currentAction.ToLower();
-            else if (!string.IsNullOrWhiteSpace(Controller))
-                res = Controller.ToLower() == currentController.ToLower();
-            else
-                res = false;
-            return res;
+
+            if(!string.IsNullOrWhiteSpace(Controller) && Controller.ToLower() != currentController.ToLower())
+            {
+                return false;
+            }
+
+            if(!string.IsNullOrWhiteSpace(Action) && Action.ToLower() != currentAction.ToLower())
+            {
+                return false;
+            }
+
+            foreach (KeyValuePair<string, string> routeValue in RouteValues)
+            {
+                if (!ViewContext.RouteData.Values.ContainsKey(routeValue.Key) || ViewContext.RouteData.Values[routeValue.Key].ToString() != routeValue.Value)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private void MakeActive(TagHelperOutput output)


### PR DESCRIPTION
NavLinkTagHelper now also takes into account other route values besides Controller and Action when evaluating ShouldBeActive().
