### PR TITLE
Remove visible HTML "asp-authorize" attribute

### DIFF
--- a/TagHelperSamples/src/TagHelperSamples.Authorization/AuthorizeTagHelper.cs
+++ b/TagHelperSamples/src/TagHelperSamples.Authorization/AuthorizeTagHelper.cs
@@ -53,6 +53,8 @@ namespace TagHelperSamples.Authorization
             {
                 output.SuppressOutput();
             }
+            
+            output.Attributes.Remove("asp-authorize");
         }
     }
 }

--- a/TagHelperSamples/src/TagHelperSamples.Authorization/AuthorizeTagHelper.cs
+++ b/TagHelperSamples/src/TagHelperSamples.Authorization/AuthorizeTagHelper.cs
@@ -54,7 +54,8 @@ namespace TagHelperSamples.Authorization
                 output.SuppressOutput();
             }
             
-            output.Attributes.Remove("asp-authorize");
+			if (output.Attributes.TryGetAttribute("asp-authorize", out TagHelperAttribute attribute))
+				output.Attributes.Remove(attribute);
         }
     }
 }


### PR DESCRIPTION
"asp-authorize" attribute is visible on HTML element when authorized.